### PR TITLE
new configuration for `prettier`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,3 +30,8 @@ repos:
     rev: 7.1.0
     hooks:
       - id: flake8
+  - repo: https://github.com/rbubley/mirrors-prettier
+    rev: v3.3.3
+    hooks:
+      - id: prettier
+        args: [--cache-location=.prettier_cache/cache]

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -1,14 +1,14 @@
 {
-    "full_name": "Prename Surname",
-    "email": "username@example.com",
-    "github_username": "username",
-    "project_name": "New templated project",
-    "repo_name": "{{ cookiecutter.project_name.lower().replace(' ', '-') }}",
-    "project_slug": "{{ cookiecutter.project_name.lower().replace(' ', '_').replace('-', '_') }}",
-    "github_repository": "https://github.com/{{ cookiecutter.github_username }}/{{ cookiecutter.repo_name }}",
-    "license": ["MIT", "BSD-3-Clause", "Apache-2.0", "Not open source"],
-    "package_manager": ["conda", "pip"],
-    "python_version": "3.10",
-    "sphinx_theme": "sphinx_rtd_theme",
-    "main_branch": "main"
+  "full_name": "Prename Surname",
+  "email": "username@example.com",
+  "github_username": "username",
+  "project_name": "New templated project",
+  "repo_name": "{{ cookiecutter.project_name.lower().replace(' ', '-') }}",
+  "project_slug": "{{ cookiecutter.project_name.lower().replace(' ', '_').replace('-', '_') }}",
+  "github_repository": "https://github.com/{{ cookiecutter.github_username }}/{{ cookiecutter.repo_name }}",
+  "license": ["MIT", "BSD-3-Clause", "Apache-2.0", "Not open source"],
+  "package_manager": ["conda", "pip"],
+  "python_version": "3.10",
+  "sphinx_theme": "sphinx_rtd_theme",
+  "main_branch": "main"
 }

--- a/{{ cookiecutter.repo_name }}/.pre-commit-config.yaml
+++ b/{{ cookiecutter.repo_name }}/.pre-commit-config.yaml
@@ -31,7 +31,8 @@ repos:
     hooks:
       - id: nbstripout
         args: [--extra-keys=metadata.kernelspec metadata.language_info.version]
-  - repo: https://github.com/pre-commit/mirrors-prettier
+  - repo: https://github.com/rbubley/mirrors-prettier
     rev: 0.0.0
     hooks:
       - id: prettier
+        args: [--cache-location=.prettier_cache/cache]


### PR DESCRIPTION
The `prettier` mirror has changed, and we didn't use it for the template repository, yet.