### PR TITLE
update the `pre-commit` configuration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,29 +4,29 @@ ci:
 # https://pre-commit.com/
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v6.0.0
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
       - id: check-docstring-first
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.12.7
+    rev: v0.15.4
     hooks:
       - id: ruff
         args: ["--fix", "--show-fixes"]
         exclude: "\\{\\{ cookiecutter.repo_name \\}\\}"
   - repo: https://github.com/psf/black-pre-commit-mirror
-    rev: 25.1.0
+    rev: 26.1.0
     hooks:
       - id: black
   - repo: https://github.com/keewis/blackdoc
-    rev: v0.4.1
+    rev: v0.4.6
     hooks:
       - id: blackdoc
-        additional_dependencies: ["black==25.1.0"]
+        additional_dependencies: ["black==26.1.0"]
       - id: blackdoc-autoupdate-black
   - repo: https://github.com/rbubley/mirrors-prettier
-    rev: v3.6.2
+    rev: v3.8.1
     hooks:
       - id: prettier
         args: ["--cache-location=.prettier_cache/cache"]

--- a/{{ cookiecutter.repo_name }}/.pre-commit-config.yaml
+++ b/{{ cookiecutter.repo_name }}/.pre-commit-config.yaml
@@ -29,7 +29,7 @@ repos:
     hooks:
       - id: nbstripout
         args:
-          ["--extra-keys=metadata.kernelspec", "metadata.language_info.version"]
+          - "--extra-keys=metadata.kernelspec metadata.language_info.version"
   - repo: https://github.com/rbubley/mirrors-prettier
     rev: 0.0.0
     hooks:

--- a/{{ cookiecutter.repo_name }}/.pre-commit-config.yaml
+++ b/{{ cookiecutter.repo_name }}/.pre-commit-config.yaml
@@ -15,14 +15,14 @@ repos:
       - id: ruff
         args: ["--fix", "--show-fixes"]
   - repo: https://github.com/psf/black-pre-commit-mirror
-    rev: 22.1.0
+    rev: 26.1.0
     hooks:
       - id: black-jupyter
   - repo: https://github.com/keewis/blackdoc
     rev: 0.0.0
     hooks:
       - id: blackdoc
-        additional_dependencies: ["black==22.1.0"]
+        additional_dependencies: ["black==26.1.0"]
       - id: blackdoc-autoupdate-black
   - repo: https://github.com/kynan/nbstripout
     rev: 0.0.0


### PR DESCRIPTION
Mainly because `black==22.1.0` does not run on modern python anymore.